### PR TITLE
daisyUIのプラグインが上手くいかない

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,4 @@
+class TopController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/top_helper.rb
+++ b/app/helpers/top_helper.rb
@@ -1,0 +1,2 @@
+module TopHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,13 +10,9 @@ require("@rails/activestorage").start()
 require("channels")
 require('./hello_vue.js')
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
 import '@fortawesome/fontawesome-free/js/all';
 import '../stylesheets/application';
-import '../stylesheets/tailwind.scss';
+
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/tailwind.config.js
+++ b/app/javascript/packs/tailwind.config.js
@@ -8,5 +8,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require("daisyui")],
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,4 @@
 @import '~@fortawesome/fontawesome-free/scss/fontawesome'; 
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";

--- a/app/javascript/stylesheets/tailwind.scss
+++ b/app/javascript/stylesheets/tailwind.scss
@@ -1,3 +1,0 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";

--- a/app/views/onomatopoeias/index.html.erb
+++ b/app/views/onomatopoeias/index.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Onomatopoeias</h1>
-<button class="inline-block cursor-pointer rounded-md bg-gray-800 px-4 py-3 text-center text-sm font-semibold uppercase text-white transition duration-200 ease-in-out hover:bg-gray-900">Button</button>
+
 <table>
   <thead>
     <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'onomatopoeias#index'
+  root to: 'top#index'
 
   resources :onomatopoeias, only: [:index]
   resources :users, only: [:new, :create]

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: [
-    require('tailwindcss')('./app/javascript/packs/tailwind.config.js'), ,
+    require('tailwindcss')('./app/javascript/packs/tailwind.config.js'),
     require('autoprefixer'),
     require('postcss-import'),
     require('postcss-flexbugs-fixes'),

--- a/spec/helpers/top_helper_spec.rb
+++ b/spec/helpers/top_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TopHelper. For example:
+#
+# describe TopHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TopHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/top_spec.rb
+++ b/spec/requests/top_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Tops", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 質問内容・実現したいこと
tailwind CSS コンポーネントライブラリのdaisyUIの導入にあたり、
`tailwind.config.js`にプラグインの記載をするとエラーが発生してしまいます。

## 現状発生している問題・エラーメッセージ
[参考記事](https://zenn.dev/nakaatsu/articles/67ee1bd74f2f8b)を元に、yarnでdaisyUIを導入し
./app/javascript/packs/tailwind.config.jsに`plugins: [require("daisyui")]`を追加したところ
```
module.exports = {
  content: ["./app/helpers/**/*.rb", "./app/javascript/packs/*.{js,vue}", "./app/views/**/*.{erb,haml,html,slim}"],
  purge: [],
  darkMode: false, // or 'media' or 'class'
  theme: {
    extend: {},
  },
  variants: {
    extend: {},
  },
  plugins: [require("daisyui")], // 追記
}
```
下記画像のようなエラーが発生しております。
[![Image from Gyazo](https://i.gyazo.com/3669b50398deda08e95a0ee363b0377a.png)](https://gyazo.com/3669b50398deda08e95a0ee363b0377a)

## どの処理までうまく動いているのか
- [参考記事](https://qiita.com/YutoYasunaga/items/9632a4b216a74328d0a4)を元に、tailwind  CSSは導入済みです。
- 下記画像の通りdaisyUIのコンポーネントの読み込みは行われていると考えます。
[![Image from Gyazo](https://i.gyazo.com/4a01a8eee2dfd7a709b1ab92ad3ed0a0.png)](https://gyazo.com/4a01a8eee2dfd7a709b1ab92ad3ed0a0)

## エラーから考えられる原因
- node_modulesの読込み方に問題があるのではないか
- yarnでdaisyUIを導入する際、使用していたnodeバージョン(15.14.0)とpostcss-jsバージョン(4.0.0)でエラーが出た為、nodeのバージョンを16.16.0に上げてインストールしました。
[![Image from Gyazo](https://i.gyazo.com/a325c0a01760ef09b84ef21187fb8473.png)](https://gyazo.com/a325c0a01760ef09b84ef21187fb8473)
エラーにも`Module build failed (from ./node_modules/postcss-loader/src/index.js):`とあるのでpostcssが何か影響をきたしているのではと考えます。

## 試したこと
- ` (1:0) Variant cannot be generated because selector contains no classes.`とある通り
`variants`にclassが設定されてないためエラーになると考え、[参考記事](https://tailwindcss.jp/docs/pseudo-class-variants)を元にviewファイルと`tailwind.config.js`の`variants`に記載しましたが変わりませんでした。
- node_modules配下にあるcss-loader/sass-loader/postcss-loaderあたりの読込み方の設定ミスかと思いファイルを確認しましたが修正する箇所の検討がつきませんでした。


お忙しいところお手数をおかけいたしますが、
何卒ご教示の程宜しくお願いいたします。