### PR TITLE
Add:master keyの設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
## 概要

- config.require_master_key設定
本番環境でYoutubeAPIを使えるようにするため、
コメントアウトし有効変更。